### PR TITLE
Fix: error message when opening config file failed

### DIFF
--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -11,7 +11,7 @@ namespace format {
   DockingConfiguration ParseInFile(const char *filename){
     std::ifstream ifs(filename);
     if (ifs.fail()){
-      std::cerr << "opening grid file failed:" << filename << std::endl;
+      std::cerr << "opening config file failed: " << filename << std::endl;
       abort();
     }
     DockingConfiguration conf;


### PR DESCRIPTION
fix #13

Message when `foo/bar.in` fails to open
- Before : `opening grid file failed:foo/bar.in`
- After    : `opening config file failed: foo/bar.in`