### PR TITLE
Delete charge if atom is *

### DIFF
--- a/src/OBMol.cc
+++ b/src/OBMol.cc
@@ -113,6 +113,7 @@ namespace format{
         del_id_list.erase(std::remove(del_id_list.begin(), del_id_list.end(), id), del_id_list.end());
 
       if (mol.getAtoms()[i].getXSType() == XS_TYPE_DUMMY) {
+        obmol.GetAtom(id + 1)->SetFormalCharge(0);
         obmol.GetAtom(id + 1)->SetAtomicNum(0);
       }
       else if (mol.getAtoms()[i].getXSType() != XS_TYPE_H) {


### PR DESCRIPTION
切断先の原子が電荷を帯びていても、アタッチメントポイントに電荷の情報を持たないように修正しました。

例：`C1=CC=C(C=C1)[NH+](C2=CC=CC=C2)C3=CC=CC=C3`
- 分割フラグメント（修正前）: `[*+][1c]1ccccc1`, `*[2NH+](*)*`, `[*+][1c]1ccccc1`, `[*+][1c]1ccccc1`
- 分割フラグメント（修正後）: `*[1c]1ccccc1`, `*[2NH+](*)*`, `*[1c]1ccccc1`, `*[1c]1ccccc1`