### PR TITLE
local optimization を 行わないオプション

### DIFF
--- a/src/Optimizer.hpp
+++ b/src/Optimizer.hpp
@@ -24,6 +24,7 @@ namespace fragdock {
     }
   public:
     explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids) : atom_grids(atom_grids) {}
+    fltype calcTotalEnergy(const Molecule &mol) const {return calcInterEnergy(mol) + mol.getIntraEnergy();}
     fltype optimize(Molecule &mol) const;
   };
 }

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -513,7 +513,7 @@ int main(int argc, char **argv){
   
   logs::lout << logs::debug << "config.poses_per_lig : " << config.poses_per_lig << endl;
   logs::lout << logs::debug << "config.pose_rmsd     : " << config.pose_rmsd << endl;
-  logs::lout << logs::debug << "config.no_local_opt  : " << (config.no_local_opt?"true":"false") << endl;
+  logs::lout << logs::debug << "config.no_local_opt  : " << (config.no_local_opt ? "True" : "False") << endl;
 
   for (const auto& p : lig_map) { // for each ligand
     const string& identifier = p.first;

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -44,6 +44,7 @@ namespace {
       ("receptor,r", value<std::string>(), "receptor file (.pdb file)")
       ("grid,g", value<std::string>(), "grid folder")
       ("memsize,m", value<int64_t>(), "fragment grid's memory size[MB]")
+      ("no-local-opt", "skip local optimization process")
       ("log", value<std::string>(), "log file")
       ("poses-per-lig", value<int64_t>(), "Number of output poses per ligand");
     options_description desc;
@@ -70,6 +71,7 @@ namespace {
     if (vmap.count("log")) conf.log_file = vmap["log"].as<std::string>();
     if (vmap.count("poses-per-lig")) conf.poses_per_lig = vmap["poses-per-lig"].as<int64_t>();
     if (vmap.count("rmsd")) conf.pose_rmsd = vmap["rmsd"].as<fltype>();
+    if (vmap.count("no-local-opt")) conf.no_local_opt = true;
     conf.checkConfigValidity();
     return conf;
   }
@@ -511,6 +513,7 @@ int main(int argc, char **argv){
   
   logs::lout << logs::debug << "config.poses_per_lig : " << config.poses_per_lig << endl;
   logs::lout << logs::debug << "config.pose_rmsd     : " << config.pose_rmsd << endl;
+  logs::lout << logs::debug << "config.no_local_opt  : " << (config.no_local_opt?"true":"false") << endl;
 
   for (const auto& p : lig_map) { // for each ligand
     const string& identifier = p.first;
@@ -523,10 +526,12 @@ int main(int argc, char **argv){
       Molecule mol = ligands_mol[param.inp_ind];
       mol.rotate(rotations_ligand[param.rotid]);
       mol.translate(pos);
-      fltype opt_total_energy = opt_grid.optimize(mol);
-      // fltype opt_total_energy = param.score;
+      fltype total_energy = opt_grid.calcTotalEnergy(mol);
+      if (!config.no_local_opt) {
+        total_energy = opt_grid.optimize(mol);
+      } 
 
-      out_mols[j] = make_pair(opt_total_energy, make_pair(param.inp_ind, mol));
+      out_mols[j] = make_pair(total_energy, make_pair(param.inp_ind, mol));
     }
     sort(out_mols.begin(), out_mols.end());
     fltype best_intra = LIMIT_ENERGY;

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -138,6 +138,12 @@ namespace format {
         boost::algorithm::trim(str);
         conf.pose_rmsd = boost::lexical_cast<fltype>(str);
       }
+      else if (boost::algorithm::starts_with(buffer, "NO_LOCAL_OPT ")) {
+        std::string str = buffer.substr(13);
+        boost::algorithm::trim(str);
+        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        conf.no_local_opt = (str != "false");
+      }
     }
 
     return conf;

--- a/src/infile_reader.hpp
+++ b/src/infile_reader.hpp
@@ -24,6 +24,7 @@ namespace format {
     int64_t mem_size;
     int64_t poses_per_lig = 1;
     fltype pose_rmsd = 0.5;
+    bool no_local_opt = false;
     const std::string getReuseGridString() {
       switch (reuse_grid) {
         case ReuseStrategy::OFFLINE: return "REUSE_OFFLINE";

--- a/testdata/testgrid.in
+++ b/testdata/testgrid.in
@@ -9,3 +9,4 @@ LIGAND testdata/G39.mol2
 LIGAND testdata/conformers.mol2
 OUTPUT testdata/G39_docked.sdf
 GRID_FOLDER testdata/grid
+NO_LOCAL_OPT false


### PR DESCRIPTION
研究プロジェクトの都合で、local optimizationを行わない設定が欲しくなったので設定を追加しようと思っています。
testdataのG39ではテスト済み、

- 出力結果が微妙に異なること
- restretto_score は local optimization を行った方が良いこと

は確認済みです。ご確認お願いします。