### PR TITLE
Bugfix RMSD calculation

### DIFF
--- a/src/RMSD.cc
+++ b/src/RMSD.cc
@@ -114,7 +114,6 @@ namespace OpenBabel{
     fltype minRMSD = HUGE_VAL;
     for (OpenBabel::OBMol cf_mol : cf_mols) { 
       fltype rmsd = matcher.computeRMSD(cf_mol);
-      logs::lout << "RMSD: " << rmsd << std::endl;
       minRMSD = std::min(minRMSD, rmsd);
     }
     return minRMSD;

--- a/src/RMSD.hpp
+++ b/src/RMSD.hpp
@@ -66,6 +66,8 @@ namespace OpenBabel {
     }
   };
 	
+  // preprocess molecule into a standardized state for heavy atom rmsd computation
+  OpenBabel::OBMol standardize_mol(const OpenBabel::OBMol& mol);
   // calculate minimum RMSD between mol and ref_mols
   fltype calc_minRMSD(const OpenBabel::OBMol& mol, const std::vector<OpenBabel::OBMol>& ref_mols);
 }


### PR DESCRIPTION
実装における参考元のコードでは、RMSDを計算するOBMolの**両方に**計算用の処理をする必要があった。

https://github.com/openbabel/openbabel/blob/701f6049c483b1349118c2ff736a7f609a84dedd/tools/obrms.cpp#L247

しかし、現在の実装では片方が標準化されずに比較をしていたため、比較した際のRMSDが常にinfになるバグが発生していた。
そのため、両方を標準化するように修正を加えた。

Closes #19 
