### PR TITLE
DecomposeMolecule関数の追加実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBABELLP = -L$(OBABEL_INSTALL_PATH)/lib
 
 .SUFFIXES: .cc .o
 
-_GRID_OBJS = grid_main.o utils.o infile_reader.o Molecule.o Vector3d.o Atom.o AtomInterEnergyGrid.o InterEnergyGrid.o EnergyCalculator.o log_writer_stream.o OBMol.o
+_GRID_OBJS = grid_main.o utils.o infile_reader.o Molecule.o Vector3d.o Atom.o AtomInterEnergyGrid.o InterEnergyGrid.o EnergyCalculator.o log_writer_stream.o OBMol.o UnionFindTree.o
 _CONFDOCK_OBJS = fraggrid_main.o Vector3d.o InterEnergyGrid.o Molecule.o Fragment.o InterEnergyGrid.o EnergyCalculator.o infile_reader.o utils.o MoleculeToFragments.o AtomInterEnergyGrid.o FragmentInterEnergyGrid.o Atom.o log_writer_stream.o UnionFindTree.o OBMol.o CalcMCFP.o Optimizer.o RMSD.o
 _ATOMDOCK_OBJS = nofrag_main.o Vector3d.o InterEnergyGrid.o Molecule.o InterEnergyGrid.o EnergyCalculator.o infile_reader.o utils.o AtomInterEnergyGrid.o Atom.o log_writer_stream.o OBMol.o Optimizer.o
 _TEST_OBJS = Atom.o EnergyCalculator.o Molecule.o utils.o Vector3d.o TestEnergyCalculator.o TestMain.o

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBABELLP = -L$(OBABEL_INSTALL_PATH)/lib
 
 .SUFFIXES: .cc .o
 
-_GRID_OBJS = grid_main.o utils.o infile_reader.o Molecule.o Vector3d.o Atom.o AtomInterEnergyGrid.o InterEnergyGrid.o EnergyCalculator.o log_writer_stream.o OBMol.o UnionFindTree.o
+_GRID_OBJS = grid_main.o utils.o infile_reader.o Molecule.o Vector3d.o Atom.o AtomInterEnergyGrid.o InterEnergyGrid.o EnergyCalculator.o log_writer_stream.o OBMol.o
 _CONFDOCK_OBJS = fraggrid_main.o Vector3d.o InterEnergyGrid.o Molecule.o Fragment.o InterEnergyGrid.o EnergyCalculator.o infile_reader.o utils.o MoleculeToFragments.o AtomInterEnergyGrid.o FragmentInterEnergyGrid.o Atom.o log_writer_stream.o UnionFindTree.o OBMol.o CalcMCFP.o Optimizer.o RMSD.o
 _ATOMDOCK_OBJS = nofrag_main.o Vector3d.o InterEnergyGrid.o Molecule.o InterEnergyGrid.o EnergyCalculator.o infile_reader.o utils.o AtomInterEnergyGrid.o Atom.o log_writer_stream.o OBMol.o Optimizer.o
 _TEST_OBJS = Atom.o EnergyCalculator.o Molecule.o utils.o Vector3d.o TestEnergyCalculator.o TestMain.o
@@ -45,7 +45,7 @@ _INTRAENERGY_OBJS = intraenergy_main.o Vector3d.o Molecule.o InterEnergyGrid.o E
 _DECOMPOSE_OBJS = decompose_main.o Vector3d.o Molecule.o Fragment.o infile_reader.o utils.o MoleculeToFragments.o Atom.o log_writer_stream.o UnionFindTree.o OBMol.o
 
 # ALL = objs atomgrid-gen conformer-docking atom-docking unittest easytest-docking score-only intraenergy-only
-ALL = atomgrid-gen conformer-docking
+ALL = atomgrid-gen conformer-docking decompose
 
 GRID_OBJS = $(patsubst %,objs/%,$(_GRID_OBJS))
 CONFDOCK_OBJS = $(patsubst %,objs/%,$(_CONFDOCK_OBJS))

--- a/src/Molecule.cc
+++ b/src/Molecule.cc
@@ -39,8 +39,10 @@ namespace fragdock {
   }
 
   void Molecule::axisRotate(const Vector3d &axis, fltype th) {
+    std::vector<int> id_set = std::vector<int>(atoms.size());
     for(int i = 0; i < atoms.size(); i++)
-      atoms[i].axisRotate(axis, th);
+      id_set[i] = i;
+    axisRotate(axis, th, id_set);
   }
 
   void Molecule::axisRotate(const Vector3d& axis, fltype th, const std::vector<int>& id_set) {

--- a/src/Molecule.cc
+++ b/src/Molecule.cc
@@ -3,7 +3,6 @@
 #include <set>
 
 #include "Molecule.hpp"
-#include "UnionFindTree.hpp"
 
 namespace fragdock {
   std::ostream& operator<< (std::ostream& os, const Bond& bond) {
@@ -50,29 +49,6 @@ namespace fragdock {
     for(int i = 0; i < id_set.size(); i++)
       atoms[id_set[i]].axisRotate(axis, th);
     translate(pos - getCenter());
-  }
-
-  void Molecule::bondRotate(const int bond_id, fltype th) {
-    if(bond_id >= bonds.size()){
-      std::cerr << "[Molecule::bondRotate] invarid bond id: " << bond_id << std::endl;
-      std::cerr << "bonds.size() = " << bonds.size() << std::endl;
-      for (int i = 0; i < bonds.size(); ++i) {
-        std::cerr << "BondId:" << i << " " << bonds[i] << std::endl;
-      }
-      exit(1);
-    }
-
-    // detect the bond is in a ring or not 
-    utils::UnionFindTree uf((int)atoms.size());
-    for(int i=0; i<bonds.size(); i++){
-      if (i == bond_id) continue;
-      const Bond &bond = bonds[i];
-      uf.unite(bond.atom_id1, bond.atom_id2);
-    }
-    if(uf.getSets()[0].size() == (int)atoms.size()) return; // do nothing
-    fragdock::Vector3d bond_axis = atoms[bonds[bond_id].atom_id2] - atoms[bonds[bond_id].atom_id1];
-    axisRotate(atoms[bonds[bond_id].atom_id1], bond_axis, th, uf.getSets()[0]);
-    //std::cout << *this << std::endl;
   }
 
   void Molecule::append(const Molecule &o) {

--- a/src/Molecule.cc
+++ b/src/Molecule.cc
@@ -287,26 +287,7 @@ namespace fragdock {
     }
 
     // check if the two molecules have the same graph distances
-    bool eq_gd = true;
-    std::vector<std::vector<int> > this_gd = getGraphDistances(), mol_gd = mol.getGraphDistances();
-    if (this_gd.size() != mol_gd.size()) {
-      eq_gd = false;
-    } else {
-      for (int i = 0; i < this_gd.size(); ++i) {
-        if (this_gd[i].size() != mol_gd[i].size()) {
-          eq_gd = false;
-          break;
-        }
-        for (int j = 0; j < this_gd[i].size(); ++j) {
-          if (this_gd[i][j] != mol_gd[i][j]) {
-            eq_gd = false;
-            break;
-          }
-        }
-        if (!eq_gd) break;
-      }
-    }
-    if (!eq_gd) {
+    if (getGraphDistances() != mol.getGraphDistances()) {
       std::cerr << "[Molecule::calcRMSD] different graph distances" << std::endl;
       return HUGE_VAL;
     }

--- a/src/Molecule.cc
+++ b/src/Molecule.cc
@@ -43,12 +43,9 @@ namespace fragdock {
       atoms[i].axisRotate(axis, th);
   }
 
-  void Molecule::axisRotate(const Vector3d& base, const Vector3d& axis, fltype th, const std::vector<int>& id_set) {
-    Vector3d pos = getCenter();
-    translate(-base);
+  void Molecule::axisRotate(const Vector3d& axis, fltype th, const std::vector<int>& id_set) {
     for(int i = 0; i < id_set.size(); i++)
       atoms[id_set[i]].axisRotate(axis, th);
-    translate(pos - getCenter());
   }
 
   void Molecule::append(const Molecule &o) {

--- a/src/Molecule.hpp
+++ b/src/Molecule.hpp
@@ -38,7 +38,7 @@ namespace fragdock {
     void rotate(fltype theta, fltype phi, fltype psi);
     void rotate(const Vector3d& vec);
     void axisRotate(const Vector3d& axis, fltype th);
-    void axisRotate(const Vector3d& base, const Vector3d& axis, fltype th, const std::vector<int>& id_set);
+    void axisRotate(const Vector3d& axis, fltype th, const std::vector<int>& id_set);
     // void bondRotate(const int bond_id, fltype th);
     void append(const Molecule &o);
     void append(const Atom &o);

--- a/src/Molecule.hpp
+++ b/src/Molecule.hpp
@@ -39,7 +39,7 @@ namespace fragdock {
     void rotate(const Vector3d& vec);
     void axisRotate(const Vector3d& axis, fltype th);
     void axisRotate(const Vector3d& base, const Vector3d& axis, fltype th, const std::vector<int>& id_set);
-    void bondRotate(const int bond_id, fltype th);
+    // void bondRotate(const int bond_id, fltype th);
     void append(const Molecule &o);
     void append(const Atom &o);
     void append(const Bond &bond);

--- a/src/Molecule.hpp
+++ b/src/Molecule.hpp
@@ -37,8 +37,9 @@ namespace fragdock {
     void translate(const Vector3d &vec);
     void rotate(fltype theta, fltype phi, fltype psi);
     void rotate(const Vector3d& vec);
-    // void axisRotate(const Vector3d& axis, fltype th);
-    // void axisRotate(const Vector3d& base, const Vector3d& axis, fltype th, const std::vector<int>& id_set);
+    void axisRotate(const Vector3d& axis, fltype th);
+    void axisRotate(const Vector3d& base, const Vector3d& axis, fltype th, const std::vector<int>& id_set);
+    void bondRotate(const int bond_id, fltype th);
     void append(const Molecule &o);
     void append(const Atom &o);
     void append(const Bond &bond);
@@ -69,6 +70,8 @@ namespace fragdock {
     void setIntraEnergy(fltype energy) { intraEnergy = energy; }
     fltype getIntraEnergy() const { return intraEnergy; }
     fltype getNrots() const;
+
+    fltype calcRMSD(const Molecule& mol) const;
 
     bool operator<(const Molecule& o) const { return identifier < o.identifier; }
     bool operator>(const Molecule& o) const { return identifier > o.identifier; }

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -243,11 +243,11 @@ namespace fragdock {
         Vector3d vec_b = atoms[b];
 
         if (dummy_atom) {
-          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_H));
-          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_H));
-        } else {
           dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
           dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
+        } else {
+          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_H));
+          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_H));
         }
         bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor));
         bonds_in_frags[set_id[b]].push_back(Bond(a, b, bond.is_rotor));

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -51,7 +51,7 @@ namespace {
     return ( c.end() != std::find(c.begin(), c.end(), v) );
   }
 
-  Molecule gen_new_mol(const Molecule& mol, const std::vector<int>& id_map) {
+  Molecule extract_substructure(const Molecule& mol, const std::vector<int>& id_map) {
     const vector<Atom> &atoms = mol.getAtoms();
     const vector<Bond> &bonds = mol.getBonds();
 
@@ -90,7 +90,7 @@ namespace {
       const Bond &bond = bonds[i];
       uf.unite(bond.atom_id1, bond.atom_id2);
     }
-    if(uf.getSets()[0].size() == (int)atoms.size()) return mol; // do nothing
+    if(uf.getSets()[0].size() == (int)atoms.size()) return mol; // all atoms are connected
     fragdock::Vector3d bond_axis = atoms[bonds[bond_id].atom_id2] - atoms[bonds[bond_id].atom_id1];
     Molecule new_mol = mol;
     new_mol.axisRotate(atoms[bonds[bond_id].atom_id1], bond_axis, th, uf.getSets()[0]);
@@ -105,9 +105,9 @@ namespace {
     atomids_subst_united.insert(atomids_subst_united.end(), atomids_subst_b.begin(), atomids_subst_b.end());
 
     // generate molecules that are united and previous
-    Molecule united_mol = gen_new_mol(mol, atomids_subst_united);
-    Molecule prev_mol_a = gen_new_mol(mol, atomids_subst_a);
-    Molecule prev_mol_b = gen_new_mol(mol, atomids_subst_b);
+    Molecule united_mol = extract_substructure(mol, atomids_subst_united);
+    Molecule prev_mol_a = extract_substructure(mol, atomids_subst_a);
+    Molecule prev_mol_b = extract_substructure(mol, atomids_subst_b);
 
     // avoid new ring generation
     int nRings_prev = ringDetector(prev_mol_a.size(), prev_mol_a.getBonds()).size()

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -1,4 +1,5 @@
 #include "MoleculeToFragments.hpp"
+#include "UnionFindTree.hpp"
 namespace {
   using namespace std;
   using namespace fragdock;
@@ -96,9 +97,7 @@ namespace {
     
     return new_mol;
   }
-}
 
-namespace fragdock {
   bool IsMergeable(const Molecule &mol, utils::UnionFindTree uf, int a, int b) {
     const vector<Atom> &atoms = mol.getAtoms();
     const vector<Bond> &bonds = mol.getBonds();
@@ -158,7 +157,9 @@ namespace fragdock {
 
     return true;
   }
+}
 
+namespace fragdock {
   vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                      int max_ring_size, 
                                      bool merge_solitary,

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -52,7 +52,8 @@ namespace {
 namespace fragdock {
   vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                      int max_ring_size, 
-                                     bool merge_solitary) { // merge_solitary is not used.
+                                     bool merge_solitary,  // merge_solitary is not used.
+                                     bool dummy_atom) {
     const vector<Atom> &atoms = mol.getAtoms();
     const vector<Bond> &bonds = mol.getBonds();
     // unite two atoms if the bond between them is NOT 'Single'
@@ -152,8 +153,13 @@ namespace fragdock {
         // near_ids[set_id[a]].push_back(b);
         // near_ids[set_id[b]].push_back(a);
 
-        dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
-        dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
+        if (dummy_atom) {
+          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_H));
+          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_H));
+        } else {
+          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
+          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
+        }
         bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor));
         bonds_in_frags[set_id[b]].push_back(Bond(a, b, bond.is_rotor));
       }
@@ -196,11 +202,12 @@ namespace fragdock {
 
   std::vector<std::vector<Fragment> > DecomposeMolecule(const std::vector<Molecule> &mols, 
                                                         int max_ring_size, 
-                                                        bool merge_solitary){
+                                                        bool merge_solitary,
+                                                        bool dummy_atom){
     std::vector<std::vector<Fragment> > ret(mols.size());
     #pragma omp parallel for // decomposition is independent process for each molecule
     for(int i=0; i<mols.size(); i++){
-      ret[i] = DecomposeMolecule(mols[i], max_ring_size, merge_solitary);
+      ret[i] = DecomposeMolecule(mols[i], max_ring_size, merge_solitary, dummy_atom);
     }
 
     return ret;

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -91,9 +91,12 @@ namespace {
       uf.unite(bond.atom_id1, bond.atom_id2);
     }
     if(uf.getSets()[0].size() == (int)atoms.size()) return mol; // all atoms are connected
+
     fragdock::Vector3d bond_axis = atoms[bonds[bond_id].atom_id2] - atoms[bonds[bond_id].atom_id1];
     Molecule new_mol = mol;
-    new_mol.axisRotate(atoms[bonds[bond_id].atom_id1], bond_axis, th, uf.getSets()[0]);
+    new_mol.translate(-atoms[bonds[bond_id].atom_id1]);
+    new_mol.axisRotate(bond_axis, th, uf.getSets()[0]);
+    new_mol.translate(mol.getCenter() - new_mol.getCenter());
     
     return new_mol;
   }

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -136,8 +136,7 @@ namespace {
 namespace fragdock {
   vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                      int max_ring_size, 
-                                     bool merge_solitary,
-                                     bool dummy_atom) {
+                                     bool merge_solitary) {
     const vector<Atom> &atoms = mol.getAtoms();
     const vector<Bond> &bonds = mol.getBonds();
     // unite two atoms if the bond between them is NOT 'Single'
@@ -265,13 +264,8 @@ namespace fragdock {
         Vector3d vec_a = atoms[a];
         Vector3d vec_b = atoms[b];
 
-        if (dummy_atom) {
-          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
-          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
-        } else {
-          dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_H));
-          dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_H));
-        }
+        dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
+        dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
         bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor));
         bonds_in_frags[set_id[b]].push_back(Bond(a, b, bond.is_rotor));
       }
@@ -309,12 +303,11 @@ namespace fragdock {
 
   std::vector<std::vector<Fragment> > DecomposeMolecule(const std::vector<Molecule> &mols, 
                                                         int max_ring_size, 
-                                                        bool merge_solitary,
-                                                        bool dummy_atom){
+                                                        bool merge_solitary){
     std::vector<std::vector<Fragment> > ret(mols.size());
     #pragma omp parallel for // decomposition is independent process for each molecule
     for(int i=0; i<mols.size(); i++){
-      ret[i] = DecomposeMolecule(mols[i], max_ring_size, merge_solitary, dummy_atom);
+      ret[i] = DecomposeMolecule(mols[i], max_ring_size, merge_solitary);
     }
 
     return ret;

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "MoleculeToFragments.hpp"
 #include "UnionFindTree.hpp"
 namespace {
@@ -74,23 +76,24 @@ namespace {
     const vector<Atom> &atoms = mol.getAtoms();
     const vector<Bond> &bonds = mol.getBonds();
 
-    if(bond_id >= bonds.size()){
-      std::cerr << "[Molecule::bondRotate] invarid bond id: " << bond_id << std::endl;
-      std::cerr << "bonds.size() = " << bonds.size() << std::endl;
+    if (bond_id >= bonds.size()) {
+      std::ostringstream oss;
+      oss << "[Molecule::bondRotate] invarid bond id: " << bond_id << std::endl;
+      oss << "bonds.size() = " << bonds.size() << std::endl;
       for (int i = 0; i < bonds.size(); ++i) {
-        std::cerr << "BondId:" << i << " " << bonds[i] << std::endl;
+        oss << "BondId:" << i << " " << bonds[i] << std::endl;
       }
-      exit(1);
+      throw std::out_of_range(oss.str());
     }
 
     // detect the bond is in a ring or not 
     utils::UnionFindTree uf((int)atoms.size());
-    for(int i=0; i<bonds.size(); i++){
+    for (int i=0; i<bonds.size(); i++) {
       if (i == bond_id) continue;
       const Bond &bond = bonds[i];
       uf.unite(bond.atom_id1, bond.atom_id2);
     }
-    if(uf.getSets()[0].size() == (int)atoms.size()) return mol; // all atoms are connected
+    if (uf.getSets()[0].size() == (int)atoms.size()) return mol; // all atoms are connected
 
     fragdock::Vector3d bond_axis = atoms[bonds[bond_id].atom_id2] - atoms[bonds[bond_id].atom_id1];
     Molecule new_mol = mol;

--- a/src/MoleculeToFragments.hpp
+++ b/src/MoleculeToFragments.hpp
@@ -8,10 +8,10 @@ namespace fragdock {
   std::vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                           int max_ring_size=-1, 
                                           bool merge_solitary=false,
-                                          bool dummy_atom=false);
+                                          bool dummy_atom=true);
   std::vector<std::vector<Fragment> > DecomposeMolecule(const std::vector<Molecule> &mols, 
                                                         int max_ring_size=-1, 
                                                         bool merge_solitary=false,
-                                                        bool dummy_atom=false);
+                                                        bool dummy_atom=true);
 }
 #endif

--- a/src/MoleculeToFragments.hpp
+++ b/src/MoleculeToFragments.hpp
@@ -1,12 +1,10 @@
 #include "common.hpp"
 #include "Fragment.hpp"
 #include "Molecule.hpp"
-#include "UnionFindTree.hpp"
 #ifndef MOLECULE_TO_FRAGMENTS_H_
 #define MOLECULE_TO_FRAGMENTS_H_
 
 namespace fragdock {
-  bool IsMergeable(const Molecule &mol, utils::UnionFindTree uf, int a, int b);
   std::vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                           int max_ring_size=-1, 
                                           bool merge_solitary=false,

--- a/src/MoleculeToFragments.hpp
+++ b/src/MoleculeToFragments.hpp
@@ -7,9 +7,11 @@
 namespace fragdock {
   std::vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                           int max_ring_size=-1, 
-                                          bool merge_solitary=true);
+                                          bool merge_solitary=false,
+                                          bool dummy_atom=false);
   std::vector<std::vector<Fragment> > DecomposeMolecule(const std::vector<Molecule> &mols, 
                                                         int max_ring_size=-1, 
-                                                        bool merge_solitary=true);
+                                                        bool merge_solitary=false,
+                                                        bool dummy_atom=false);
 }
 #endif

--- a/src/MoleculeToFragments.hpp
+++ b/src/MoleculeToFragments.hpp
@@ -7,11 +7,9 @@
 namespace fragdock {
   std::vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                           int max_ring_size=-1, 
-                                          bool merge_solitary=false,
-                                          bool dummy_atom=true);
+                                          bool merge_solitary=false);
   std::vector<std::vector<Fragment> > DecomposeMolecule(const std::vector<Molecule> &mols, 
                                                         int max_ring_size=-1, 
-                                                        bool merge_solitary=false,
-                                                        bool dummy_atom=true);
+                                                        bool merge_solitary=false);
 }
 #endif

--- a/src/MoleculeToFragments.hpp
+++ b/src/MoleculeToFragments.hpp
@@ -1,10 +1,12 @@
 #include "common.hpp"
 #include "Fragment.hpp"
 #include "Molecule.hpp"
+#include "UnionFindTree.hpp"
 #ifndef MOLECULE_TO_FRAGMENTS_H_
 #define MOLECULE_TO_FRAGMENTS_H_
 
 namespace fragdock {
+  bool IsMergeable(const Molecule &mol, utils::UnionFindTree uf, int a, int b);
   std::vector<Fragment> DecomposeMolecule(const Molecule &mol, 
                                           int max_ring_size=-1, 
                                           bool merge_solitary=false,

--- a/src/OBMol.cc
+++ b/src/OBMol.cc
@@ -85,9 +85,12 @@ namespace format{
 
     fragdock::Molecule mol(fatoms, obmol.GetTitle(), OpenBabel::canonicalSmiles(obmol));
     for(int i = 0; i < obmol.NumBonds(); i++){
+      bool is_rotor = obmol.GetBond(i)->IsRotor() 
+                   || obmol.GetBond(i)->GetBeginAtom()->IsHydrogen() 
+                   || obmol.GetBond(i)->GetEndAtom()->IsHydrogen();
       mol.append(fragdock::Bond(obmol.GetBond(i)->GetBeginAtom()->GetId(),
 				obmol.GetBond(i)->GetEndAtom()->GetId(),
-				obmol.GetBond(i)->IsRotor() ));
+				is_rotor ));
 				// obmol.GetBond(i)->IsRotor() || (obmol.GetBond(i)->IsSingle() && !obmol.GetBond(i)->IsInRing()) ));
     }
 

--- a/src/decompose_main.cc
+++ b/src/decompose_main.cc
@@ -39,7 +39,7 @@ namespace {
     options.add_options()
       ("help,h", "show help")
       ("fragment,f", value<std::string>(), "fragment file (.mol2 file)")
-      ("ligand,l", value<std::vector<std::string> >()->multitoken(), "ligand file")
+      ("ligand,l", value<std::vector<std::string> >()->multitoken(), "ligand file (NOT 1D structures!)")
       ("output,o", value<std::string>(), "output (annotated) ligand file (.sdf file)")
       ("log", value<std::string>(), "log file")
       ("capping_atomic_num", value<int>()->default_value(-1), "The atomic number of capping atoms. No capping if it is set to -1")

--- a/src/decompose_main.cc
+++ b/src/decompose_main.cc
@@ -117,7 +117,7 @@ namespace {
       std::vector<std::string> frag_smiles;
       OpenBabel::OBMol obmol = molecules[i];
       fragdock::Molecule mol = convert_molecule(obmol);
-      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary, true);
+      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary, false);
       
       for(std::vector<fragdock::Fragment>::iterator fit=frags.begin(); fit!=frags.end(); ++fit){
         OpenBabel::OBMol obmol = format::toOBMol(*fit, molecules[i], capping_atomic_num, capping_for_carbon, insert_fragment_id_to_isotope);

--- a/src/decompose_main.cc
+++ b/src/decompose_main.cc
@@ -117,7 +117,7 @@ namespace {
       std::vector<std::string> frag_smiles;
       OpenBabel::OBMol obmol = molecules[i];
       fragdock::Molecule mol = convert_molecule(obmol);
-      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary, false);
+      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary);
       
       for(std::vector<fragdock::Fragment>::iterator fit=frags.begin(); fit!=frags.end(); ++fit){
         OpenBabel::OBMol obmol = format::toOBMol(*fit, molecules[i], capping_atomic_num, capping_for_carbon, insert_fragment_id_to_isotope);

--- a/src/decompose_main.cc
+++ b/src/decompose_main.cc
@@ -117,7 +117,7 @@ namespace {
       std::vector<std::string> frag_smiles;
       OpenBabel::OBMol obmol = molecules[i];
       fragdock::Molecule mol = convert_molecule(obmol);
-      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary);
+      std::vector<fragdock::Fragment> frags = fragdock::DecomposeMolecule(mol, max_ring_size, merge_solitary, true);
       
       for(std::vector<fragdock::Fragment>::iterator fit=frags.begin(); fit!=frags.end(); ++fit){
         OpenBabel::OBMol obmol = format::toOBMol(*fit, molecules[i], capping_atomic_num, capping_for_carbon, insert_fragment_id_to_isotope);


### PR DESCRIPTION
# 内容
- フラグメント分割時に切断部分をアタッチメントポイントにするか水素原子にするか指定できる`dummy_atom`オプションの実装
- 化合物をフラグメントに分割する際に、重原子1つのみのフラグメント（孤立原子）が存在する場合は他のフラグメントに吸収する`merge_solitary`オプションの実装

# 実装
## dummy_atom
- `dummy_atom`が`true`ならアタッチメントポイント、`false`なら水素原子
  - `fraggrid_main.cc`は`true`固定
    - `DecomposeMolecule`関数のデフォルト引数で指定
  - `decompose_main.cc`は`false`固定
    - 引数ハードコーディング
    - confは未設定
## merge_solitary
- `DecomposeMolecule`関数に、孤立原子を他フラグメントに吸収する処理を追加
  - 孤立原子を隣接するフラグメントに吸収させた場合、回転可能な結合を1rad回転させたときの構造変化（RMSD）を見て吸収させても良いか判断
- `Molecule`クラスに、結合を軸にした回転処理メソッド`bondRotate`を追加
  - 環構造識別に`UnionFindTree`を用いているため、includeを追加・Makefileを修正
- `Molecule`クラスに、別MoleculeオブジェクトとのRMSDを計算するメソッド`calcRMSD`を追加