### PR TITLE
環の中にあるかをfragdock::Bondに記録

### DIFF
--- a/src/Molecule.cc
+++ b/src/Molecule.cc
@@ -187,7 +187,7 @@ namespace fragdock {
       assert(vec[dict[a]] > 0 && vec[dict[b]] > 0);
       newbond_ids[vec[dict[a]] - 1].push_back(newbonds.size());
       newbond_ids[vec[dict[b]] - 1].push_back(newbonds.size());
-      newbonds.push_back(Bond(vec[dict[a]] - 1, vec[dict[b]] - 1, bonds[i].is_rotor));
+      newbonds.push_back(Bond(vec[dict[a]] - 1, vec[dict[b]] - 1, bonds[i].is_rotor, bonds[i].is_in_ring));
     }
     for (int i = 0; i < newsz; ++i) {
       newatoms[i].setId(i);

--- a/src/Molecule.hpp
+++ b/src/Molecule.hpp
@@ -13,9 +13,9 @@
 namespace fragdock {
   struct Bond {
     int atom_id1, atom_id2;
-    bool is_rotor;
+    bool is_rotor, is_in_ring;
     friend std::ostream& operator<< (std::ostream& os, const Bond& bond);
-    Bond(const int atom_id1, const int atom_id2, const bool is_rotor) : atom_id1(atom_id1), atom_id2(atom_id2), is_rotor(is_rotor) {}
+    Bond(const int atom_id1, const int atom_id2, const bool is_rotor, const bool is_in_ring) : atom_id1(atom_id1), atom_id2(atom_id2), is_rotor(is_rotor), is_in_ring(is_in_ring) {}
   };
   class Molecule {
   protected:

--- a/src/MoleculeToFragments.cc
+++ b/src/MoleculeToFragments.cc
@@ -272,11 +272,11 @@ namespace fragdock {
 
         dummys[set_id[a]].push_back(Atom(b, vec_b, XS_TYPE_DUMMY));
         dummys[set_id[b]].push_back(Atom(a, vec_a, XS_TYPE_DUMMY));
-        bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor));
-        bonds_in_frags[set_id[b]].push_back(Bond(a, b, bond.is_rotor));
+        bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor, bond.is_in_ring));
+        bonds_in_frags[set_id[b]].push_back(Bond(a, b, bond.is_rotor, bond.is_in_ring));
       }
       else {
-        bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor));
+        bonds_in_frags[set_id[a]].push_back(Bond(a, b, bond.is_rotor, bond.is_in_ring));
       }
     }
     // create fragments

--- a/src/OBMol.cc
+++ b/src/OBMol.cc
@@ -85,13 +85,13 @@ namespace format{
 
     fragdock::Molecule mol(fatoms, obmol.GetTitle(), OpenBabel::canonicalSmiles(obmol));
     for(int i = 0; i < obmol.NumBonds(); i++){
-      bool is_rotor = obmol.GetBond(i)->IsRotor() 
+      bool is_rotor = obmol.GetBond(i)->IsRotor(true) 
                    || obmol.GetBond(i)->GetBeginAtom()->IsHydrogen() 
                    || obmol.GetBond(i)->GetEndAtom()->IsHydrogen();
       mol.append(fragdock::Bond(obmol.GetBond(i)->GetBeginAtom()->GetId(),
-				obmol.GetBond(i)->GetEndAtom()->GetId(),
-				is_rotor ));
-				// obmol.GetBond(i)->IsRotor() || (obmol.GetBond(i)->IsSingle() && !obmol.GetBond(i)->IsInRing()) ));
+				                        obmol.GetBond(i)->GetEndAtom()->GetId(),
+				                        is_rotor, 
+                                obmol.GetBond(i)->IsInRing()));
     }
 
     return mol;


### PR DESCRIPTION
close #26 

- 変更内容：https://github.com/akiyamalab/restretto/issues/26#issue-2405626787
- `bond_rotate()`は環構造の**原子**集合を考える必要があるため、UnionFindTreeは置き換えていません。
  - https://github.com/akiyamalab/restretto/pull/25#discussion_r1676762929
  - 認識が間違っていましたらご指摘お願いします。