### PR TITLE
孤立原子統合のアルゴリズム変更

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -7,5 +7,6 @@ typedef float fltype;
 const fltype INF_ENERGY = 1e9;
 const fltype LIMIT_ENERGY = 1e2;
 const fltype EPS = 1e-4;
+const fltype RAD_EPS = 0.2;
 
 #endif


### PR DESCRIPTION
# 変更内容
- 孤立原子統合のアルゴリズム変更
  - **変更前**：統合した場合の回転可能な結合を実際に回転させて構造の変化を見て、実際に統合するか判断
  - **変更後**：暫定フラグメントAの原子aと暫定フラグメントBの原子bで統合する場合、「abベクトルとac（cは暫定フラグメントBの任意の原子）ベクトルのなす角の最大値」と「abベクトルとd（dは暫定フラグメントDの任意の原子）ベクトルのなす角の最大値」を見て、実際に統合するか判断
    - 角度の閾値は0.2 rad（約10°）にしている。手元で複数試したところ、最大値は0の次が0.4 radくらいであるため、0.1~0.3程度が妥当か。
- `IsMergeable()`から関数切り出し
  - 前半で定義したオブジェクトを後半（角度計算）に用いなかったため、`IsNewRing()`として切り出し
    - 実際に`IsNewRing()`が必要な場面が想像できないため、そもそも不要かもしれない。

個人的に`id_1`と`id_2`の所属フラグメント判定や`calc_max_angle()`の入出力が綺麗ではないと思ってはいますが、他の箇所でもご指摘あればよろしくお願いいたします。