### PR TITLE
静的リンクによる実行可能ファイルの作成

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,2 @@
-FROM kyanagis/restretto:1.0
+FROM kyanagis/restretto:1.1
 
-# To suppress interactive installation of boost
-ARG DEBIAN_FRONTEND=noninteractive
-
-# post processing
-RUN echo "alias ls='ls --color=auto'" >> /etc/bash.bashrc
-
-# ====== settings for git / ssh =======
-RUN echo "mkdir -p /root/.ssh" >> /etc/bash.bashrc
-RUN echo "cp /root/.ssh_host/* /root/.ssh/" >> /etc/bash.bashrc
-RUN echo "chmod 600 /root/.ssh/*" >> /etc/bash.bashrc

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ else
 OMPFLAG =
 endif
 
+ifeq ($(STATIC),Y)
+STATICFLAG = -s -lz -static
+else
+STATICFLAG =
+endif
+
 CXXFLAGS += $(OMPFLAG)
 
 ifeq ($(BOOST_INSTALL_PATH),)
@@ -65,28 +71,28 @@ objs:
 	mkdir -p objs/test
 
 atomgrid-gen: $(GRID_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 conformer-docking: $(CONFDOCK_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 atom-docking: $(ATOMDOCK_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 unittest: $(TEST_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_unit_test_framework -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_unit_test_framework -lopenbabel $(STATICFLAG)
 
 easytest-docking: $(EASYTEST_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 score-only: $(SCOREONLY_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 intraenergy-only: $(INTRAENERGY_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 decompose: $(DECOMPOSE_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(BOOSTLP) $(OBABELLP) -lboost_regex -lboost_program_options -lopenbabel $(STATICFLAG)
 
 
 objs/%.o: src/%.cc src/%.hpp src/common.hpp


### PR DESCRIPTION
libcoffeeに REstretto などの実行可能ファイルを置く際に、libcoffee自体に openbabel 2.4.1 のインストール制約を付けたくなかったので依存関係を持たない実行可能ファイルの作成を行えるようにしました。

### 修正点
- Dockerイメージの更新：`restretto:1.0` では、openbabelが動的ライブラリ（.soファイル）しか存在していなかったので、新しく静的ライブラリ（.aファイル）も配置し、 `restretto:1.1` としました。
- 静的リンクを行うようなMakefileのオプションを追加しました。

### ご確認いただきたい点
実行可能ファイルについて、Usageが表示できることは確認しているのですが、動作に影響がないことをご確認いただけると有難いです。テストデータに対しての実行結果が変わらない、ということを確認すれば十分だと思っています。