### PR TITLE
conformer-dockingのオプション追加

### DIFF
--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -31,7 +31,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (max_rmsd >= 0 && first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = ec.getEnergy(tmp_mol, receptor);
         if(val < next_val) {
@@ -79,7 +79,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (max_rmsd >= 0 && first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = calcInterEnergy(tmp_mol) + mol.getIntraEnergy();
         if(val < next_val) {

--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -11,6 +11,7 @@ namespace fragdock {
     const int NEAREST_NUM = 200;
     fltype trans_step = 0.5;
     fltype rotate_step = pi / 30.0;
+    Molecule first_mol = mol;
     while(true) {
       fltype next_val = 1e10;
       Molecule next_mol = mol;
@@ -29,6 +30,8 @@ namespace fragdock {
         tmp_mol.rotate(th, phi, psi);
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
+
+        if (max_rmsd >= 0 && first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = ec.getEnergy(tmp_mol, receptor);
         if(val < next_val) {
@@ -56,6 +59,7 @@ namespace fragdock {
     const int NEAREST_NUM = 200;
     fltype trans_step = 0.5;
     fltype rotate_step = pi / 30.0;
+    Molecule first_mol = mol;
     while(true) {
       fltype next_val = 1e10;
       Molecule next_mol = mol;
@@ -74,6 +78,8 @@ namespace fragdock {
         tmp_mol.rotate(th, phi, psi);
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
+
+        if (max_rmsd >= 0 && first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = calcInterEnergy(tmp_mol) + mol.getIntraEnergy();
         if(val < next_val) {

--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -11,7 +11,7 @@ namespace fragdock {
     const int NEAREST_NUM = 200;
     fltype trans_step = 0.5;
     fltype rotate_step = pi / 30.0;
-    Molecule first_mol = mol;
+    Molecule initial_mol = mol;
     while(true) {
       fltype next_val = 1e10;
       Molecule next_mol = mol;
@@ -31,7 +31,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (initial_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = ec.getEnergy(tmp_mol, receptor);
         if(val < next_val) {
@@ -59,7 +59,7 @@ namespace fragdock {
     const int NEAREST_NUM = 200;
     fltype trans_step = 0.5;
     fltype rotate_step = pi / 30.0;
-    Molecule first_mol = mol;
+    Molecule initial_mol = mol;
     while(true) {
       fltype next_val = 1e10;
       Molecule next_mol = mol;
@@ -79,7 +79,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (first_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (initial_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
 
         fltype val = calcInterEnergy(tmp_mol) + mol.getIntraEnergy();
         if(val < next_val) {

--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -31,7 +31,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (initial_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (initial_mol.calcRMSD(tmp_mol) > this->max_rmsd) continue;
 
         fltype val = ec.getEnergy(tmp_mol, receptor);
         if(val < next_val) {
@@ -79,7 +79,7 @@ namespace fragdock {
         tmp_mol.translate(center + dv);
         // tmp_mol.translate(dv);
 
-        if (initial_mol.calcRMSD(tmp_mol) > max_rmsd) continue;
+        if (initial_mol.calcRMSD(tmp_mol) > this->max_rmsd) continue;
 
         fltype val = calcInterEnergy(tmp_mol) + mol.getIntraEnergy();
         if(val < next_val) {

--- a/src/Optimizer.hpp
+++ b/src/Optimizer.hpp
@@ -9,8 +9,7 @@ namespace fragdock {
     const Molecule& receptor;
     const fltype max_rmsd;
   public:
-    explicit Optimizer(const Molecule& receptor) : receptor(receptor), max_rmsd(-1.0) {}
-    explicit Optimizer(const Molecule& receptor, fltype max_rmsd) : receptor(receptor), max_rmsd(max_rmsd) {}
+    explicit Optimizer(const Molecule& receptor, fltype max_rmsd = 1e10) : receptor(receptor), max_rmsd(max_rmsd) {}
     fltype optimize(Molecule &mol, const EnergyCalculator& ec) const;
   };
 
@@ -26,8 +25,7 @@ namespace fragdock {
       return ret;
     }
   public:
-    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids) : atom_grids(atom_grids), max_rmsd(-1.0) {}
-    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids, fltype max_rmsd) : atom_grids(atom_grids), max_rmsd(max_rmsd) {}
+    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids, fltype max_rmsd = 1e10) : atom_grids(atom_grids), max_rmsd(max_rmsd) {}
     fltype calcTotalEnergy(const Molecule &mol) const {return calcInterEnergy(mol) + mol.getIntraEnergy();}
     fltype optimize(Molecule &mol) const;
   };

--- a/src/Optimizer.hpp
+++ b/src/Optimizer.hpp
@@ -7,14 +7,17 @@
 namespace fragdock {
   class Optimizer {
     const Molecule& receptor;
+    const fltype max_rmsd;
   public:
-    explicit Optimizer(const Molecule& receptor) : receptor(receptor) {}
+    explicit Optimizer(const Molecule& receptor) : receptor(receptor), max_rmsd(-1.0) {}
+    explicit Optimizer(const Molecule& receptor, fltype max_rmsd) : receptor(receptor), max_rmsd(max_rmsd) {}
     fltype optimize(Molecule &mol, const EnergyCalculator& ec) const;
   };
 
   class Optimizer_Grid {
     const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids;
     // const Molecule& receptor;
+    const fltype max_rmsd;
     fltype calcInterEnergy(const Molecule &mol) const {
       fltype ret = 0.0;
       for (auto& a : mol.getAtoms()) {
@@ -23,7 +26,8 @@ namespace fragdock {
       return ret;
     }
   public:
-    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids) : atom_grids(atom_grids) {}
+    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids) : atom_grids(atom_grids), max_rmsd(-1.0) {}
+    explicit Optimizer_Grid(const std::vector<fragdock::AtomInterEnergyGrid>& atom_grids, fltype max_rmsd) : atom_grids(atom_grids), max_rmsd(max_rmsd) {}
     fltype calcTotalEnergy(const Molecule &mol) const {return calcInterEnergy(mol) + mol.getIntraEnergy();}
     fltype optimize(Molecule &mol) const;
   };

--- a/src/decompose_main.cc
+++ b/src/decompose_main.cc
@@ -173,7 +173,7 @@ int main(int argc, char** argv){
   if(config.log_file == ""){
     config.log_file = (config.output_file + "__" + utils::getDate() + ".log");
   }
-  logs::log_init(config.log_file, true);
+  logs::set_file(config.log_file, true);
 
   // preparing ligand data
   std::vector<std::vector<int> > mol2frag_list;

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -515,7 +515,7 @@ int main(int argc, char **argv){
 
   // Optimizer opt(receptor_mol);
   // vector<AtomInterEnergyGrid> opt_atom_grids = AtomInterEnergyGrid::makeAtomGrids(atom_grids[0].getCenter(), atom_grids[0].getPitch(), atom_grids[0].getNum(), receptor_mol, calc);
-  Optimizer_Grid opt_grid(atom_grids);
+  Optimizer_Grid opt_grid(atom_grids, config.local_max_rmsd);
 
   logs::lout << logs::info << "end pre-calculate energy" << endl;
 
@@ -527,6 +527,9 @@ int main(int argc, char **argv){
   logs::lout << logs::debug << "config.poses_per_lig : " << config.poses_per_lig << endl;
   logs::lout << logs::debug << "config.pose_min_rmsd     : " << config.pose_min_rmsd << endl;
   logs::lout << logs::debug << "config.no_local_opt  : " << (config.no_local_opt ? "True" : "False") << endl;
+  if (!config.no_local_opt) {
+    logs::lout << logs::debug << "config.local_max_rmsd : " << ((config.local_max_rmsd < 0) ? "None" : to_string(config.local_max_rmsd)) << endl;
+  }
 
   for (const auto& p : lig_map) { // for each ligand
     const string& identifier = p.first;

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -105,9 +105,9 @@ namespace {
     logs::lout << "Output file name    : "+config.output_file     << std::endl;
     logs::lout << "Grid folder name    : "+config.grid_folder     << std::endl;
     logs::lout << "Memory size[MB]     : "<<config.mem_size       << std::endl;
-    if (config.score_only) logs::lout <<   "[Option] Score only mode" << std::endl;
-    if (config.no_local_opt) logs::lout << "[Option] No local opt mode" << std::endl;
-    if (config.local_only) logs::lout << "[Option] Local only mode" << std::endl;
+    logs::lout << "Score only mode     : "<<(config.score_only?"True":"False") << std::endl;
+    logs::lout << "No local opt mode   : "<<(config.no_local_opt?"True":"False") << std::endl;
+    logs::lout << "Local only mode     : "<<(config.local_only?"True":"False") << std::endl;
   }
 
   struct pos_param {
@@ -549,8 +549,8 @@ int main(int argc, char **argv){
     logs::lout << logs::debug << "config.poses_per_lig : " << config.poses_per_lig << endl;
     logs::lout << logs::debug << "config.pose_min_rmsd : " << config.pose_min_rmsd << endl;
   }
-  if (!config.no_local_opt && !config.score_only) {
-    logs::lout << logs::debug << "config.local_max_rmsd : " << ((config.local_max_rmsd < 0) ? "None" : to_string(config.local_max_rmsd)) << endl;
+  if (!config.no_local_opt || !config.score_only) {
+    logs::lout << logs::debug << "config.local_max_rmsd : " << ((config.local_max_rmsd > 1e8) ? "None" : to_string(config.local_max_rmsd)) << endl;
   }
 
   if (!no_search) {

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -44,7 +44,10 @@ namespace {
       ("receptor,r", value<std::string>(), "receptor file (.pdb file)")
       ("grid,g", value<std::string>(), "grid folder")
       ("memsize,m", value<int64_t>(), "fragment grid's memory size[MB]")
+      ("score-only", "search space can be omitted")
       ("no-local-opt", "skip local optimization process")
+      ("local-only", "do local search only")
+      ("local-max-rmsd", value<fltype>(), "maximum RMSD for local search")
       ("log", value<std::string>(), "log file")
       ("poses-per-lig", value<int64_t>(), "Number of output poses per ligand")
       ("rmsd", value<fltype>(), "rmsd threshold for output poses")
@@ -71,6 +74,9 @@ namespace {
     if (vmap.count("output")) conf.output_file = vmap["output"].as<std::string>();
     if (vmap.count("grid")) conf.grid_folder = vmap["grid"].as<std::string>();
     if (vmap.count("memsize")) conf.mem_size = vmap["memsize"].as<int64_t>();
+    if (vmap.count("score-only")) conf.score_only = true;
+    if (vmap.count("local-only")) conf.local_only = true;
+    if (vmap.count("local-max-rmsd")) conf.local_max_rmsd = vmap["local-max-rmsd"].as<fltype>();
     if (vmap.count("log")) conf.log_file = vmap["log"].as<std::string>();
     if (vmap.count("poses-per-lig")) conf.poses_per_lig = vmap["poses-per-lig"].as<int64_t>();
     if (vmap.count("rmsd")) conf.pose_rmsd = vmap["rmsd"].as<fltype>();

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -228,7 +228,7 @@ int main(int argc, char **argv){
   if(config.log_file == ""){
     config.log_file = config.output_file + "fraggrid__" + getDate() + ".log";
   }
-  logs::log_init(config.log_file, true);
+  logs::set_file(config.log_file, true);
   logConfig(config);
 
   // parse receptor file

--- a/src/grid_main.cc
+++ b/src/grid_main.cc
@@ -91,7 +91,7 @@ int main(int argc, char **argv){
   makeFolder(conf.grid_folder);
 
   //Prepareing logger
-  logs::log_init("atomgrid-gen.log");
+  logs::set_file("atomgrid-gen.log");
 
   // logs::lout << logs::info << "Read parameter file. " << conf.forcefield_file;
   // fragdock::AtomType::setAtomParams(conf.forcefield_file.c_str());

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -154,6 +154,23 @@ namespace format {
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
         conf.no_local_opt = (str != "false");
       }
+      else if (boost::algorithm::starts_with(buffer, "SCORE_ONLY ")) {
+        std::string str = buffer.substr(11);
+        boost::algorithm::trim(str);
+        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        conf.score_only = (str != "false");
+      }
+      else if (boost::algorithm::starts_with(buffer, "LOCAL_ONLY ")) {
+        std::string str = buffer.substr(11);
+        boost::algorithm::trim(str);
+        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        conf.local_only = (str != "false");
+      }
+      else if (boost::algorithm::starts_with(buffer, "LOCAL_MAX_RMSD ")) {
+        std::string str = buffer.substr(15);
+        boost::algorithm::trim(str);
+        conf.local_max_rmsd = boost::lexical_cast<fltype>(str);
+      }
     }
 
     return conf;
@@ -169,5 +186,8 @@ namespace format {
     const fragdock::Point3d<int> num = utils::ceili(grid.outer_width / 2 / grid.score_pitch) * 2 + 1; // # of grid points per axis
     int FGRID_SIZE = (int)((mem_size * 1024 * 1024) / ((int64_t) num.x * num.y * num.z * sizeof(fltype))); // # of grids that can be stored in memory
     assert(FGRID_SIZE > 0);
+
+    // option conflict check
+    assert(score_only + local_only + no_local_opt <= 1);
   }
 } // namespace format

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -96,12 +96,8 @@ namespace format {
         std::string str = buffer.substr(16);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        if (str == "true") {
-          conf.reorder = true;
-        }
-        else if (str == "false") {
-          conf.reorder = false;
-        }
+        if (str == "true") conf.reorder = true;
+        else if (str == "false") conf.reorder = false;
         else {
           std::cerr << "Error: invalid value for REORDER_LIGANDS. It must be either 'true' or 'false'." << std::endl;
           abort();
@@ -161,12 +157,8 @@ namespace format {
         std::string str = buffer.substr(13);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        if (str == "true") {
-          conf.no_local_opt = true;
-        }
-        else if (str == "false") {
-          conf.no_local_opt = false;
-        }
+        if (str == "true") conf.no_local_opt = true;
+        else if (str == "false") conf.no_local_opt = false;
         else {
           std::cerr << "Error: invalid value for NO_LOCAL_OPT. It must be either 'true' or 'false'." << std::endl;
           abort();
@@ -176,12 +168,8 @@ namespace format {
         std::string str = buffer.substr(11);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        if (str == "true") {
-          conf.score_only = true;
-        }
-        else if (str == "false") {
-          conf.score_only = false;
-        }
+        if (str == "true") conf.score_only = true;
+        else if (str == "false") conf.score_only = false;
         else {
           std::cerr << "Error: invalid value for SCORE_ONLY. It must be either 'true' or 'false'." << std::endl;
           abort();
@@ -191,12 +179,8 @@ namespace format {
         std::string str = buffer.substr(11);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        if (str == "true") {
-          conf.local_only = true;
-        }
-        else if (str == "false") {
-          conf.local_only = false;
-        }
+        if (str == "true") conf.local_only = true;
+        else if (str == "false") conf.local_only = false;
         else {
           std::cerr << "Error: invalid value for LOCAL_ONLY. It must be either 'true' or 'false'." << std::endl;
           abort();

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -143,10 +143,10 @@ namespace format {
         boost::algorithm::trim(str);
         conf.output_score_threshold = boost::lexical_cast<fltype>(str);
       }
-      else if (boost::algorithm::starts_with(buffer, "POSE_RMSD ")) {
-        std::string str = buffer.substr(10);
+      else if (boost::algorithm::starts_with(buffer, "MIN_RMSD ")) {
+        std::string str = buffer.substr(9);
         boost::algorithm::trim(str);
-        conf.pose_rmsd = boost::lexical_cast<fltype>(str);
+        conf.pose_min_rmsd = boost::lexical_cast<fltype>(str);
       }
       else if (boost::algorithm::starts_with(buffer, "NO_LOCAL_OPT ")) {
         std::string str = buffer.substr(13);

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -188,8 +188,16 @@ namespace format {
     assert(FGRID_SIZE > 0);
 
     // option conflict check (do not set at the same time)
-    assert(
-      !( (score_only && local_only) || (score_only && no_local_opt) || (local_only && no_local_opt) )
-    );
+    if (score_only && local_only) {
+      std::cerr << "Error: 'score-only' and 'local-only' cannot be true at the same time." << std::endl;
+      abort();
+    }
+    if (score_only && no_local_opt) {
+      std::cerr << "Warning: 'score-only' and 'no-local-opt' are both true. This means the same as 'score-only' only." << std::endl;
+    }
+    if (local_only && no_local_opt) {
+      std::cerr << "Warning: 'local-only' and 'no-local-opt' are both true. This may the same as 'score-only'." << std::endl;
+    }
+
   }
 } // namespace format

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -96,7 +96,16 @@ namespace format {
         std::string str = buffer.substr(16);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        conf.reorder = (str != "false");
+        if (str == "true") {
+          conf.reorder = true;
+        }
+        else if (str == "false") {
+          conf.reorder = false;
+        }
+        else {
+          std::cerr << "Error: invalid value for REORDER_LIGANDS. It must be either 'true' or 'false'." << std::endl;
+          abort();
+        }
       }
       else if (boost::algorithm::starts_with(buffer, "MEMORY_SIZE ")) {
         // fraggrid_main の方でデフォルト値を設定しちゃったから使えないような気がする
@@ -152,19 +161,46 @@ namespace format {
         std::string str = buffer.substr(13);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        conf.no_local_opt = (str != "false");
+        if (str == "true") {
+          conf.no_local_opt = true;
+        }
+        else if (str == "false") {
+          conf.no_local_opt = false;
+        }
+        else {
+          std::cerr << "Error: invalid value for NO_LOCAL_OPT. It must be either 'true' or 'false'." << std::endl;
+          abort();
+        }
       }
       else if (boost::algorithm::starts_with(buffer, "SCORE_ONLY ")) {
         std::string str = buffer.substr(11);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        conf.score_only = (str != "false");
+        if (str == "true") {
+          conf.score_only = true;
+        }
+        else if (str == "false") {
+          conf.score_only = false;
+        }
+        else {
+          std::cerr << "Error: invalid value for SCORE_ONLY. It must be either 'true' or 'false'." << std::endl;
+          abort();
+        }
       }
       else if (boost::algorithm::starts_with(buffer, "LOCAL_ONLY ")) {
         std::string str = buffer.substr(11);
         boost::algorithm::trim(str);
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        conf.local_only = (str != "false");
+        if (str == "true") {
+          conf.local_only = true;
+        }
+        else if (str == "false") {
+          conf.local_only = false;
+        }
+        else {
+          std::cerr << "Error: invalid value for LOCAL_ONLY. It must be either 'true' or 'false'." << std::endl;
+          abort();
+        }
       }
       else if (boost::algorithm::starts_with(buffer, "LOCAL_MAX_RMSD ")) {
         std::string str = buffer.substr(15);

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -11,7 +11,7 @@ namespace format {
   DockingConfiguration ParseInFile(const char *filename){
     std::ifstream ifs(filename);
     if (ifs.fail()){
-      std::cerr << "opening config file failed: " << filename << std::endl;
+      logs::lerr << logs::error << "opening config file failed: " << filename << std::endl;
       abort();
     }
     DockingConfiguration conf;
@@ -99,7 +99,7 @@ namespace format {
         if (str == "true") conf.reorder = true;
         else if (str == "false") conf.reorder = false;
         else {
-          std::cerr << "Error: invalid value for REORDER_LIGANDS. It must be either 'true' or 'false'." << std::endl;
+          logs::lerr << logs::error << "invalid value for REORDER_LIGANDS. It must be either 'true' or 'false'." << std::endl;
           abort();
         }
       }
@@ -160,7 +160,7 @@ namespace format {
         if (str == "true") conf.no_local_opt = true;
         else if (str == "false") conf.no_local_opt = false;
         else {
-          std::cerr << "Error: invalid value for NO_LOCAL_OPT. It must be either 'true' or 'false'." << std::endl;
+          logs::lerr << logs::error << "Error: invalid value for NO_LOCAL_OPT. It must be either 'true' or 'false'." << std::endl;
           abort();
         }
       }
@@ -171,7 +171,7 @@ namespace format {
         if (str == "true") conf.score_only = true;
         else if (str == "false") conf.score_only = false;
         else {
-          std::cerr << "Error: invalid value for SCORE_ONLY. It must be either 'true' or 'false'." << std::endl;
+          logs::lerr << logs::error << "Error: invalid value for SCORE_ONLY. It must be either 'true' or 'false'." << std::endl;
           abort();
         }
       }
@@ -182,7 +182,7 @@ namespace format {
         if (str == "true") conf.local_only = true;
         else if (str == "false") conf.local_only = false;
         else {
-          std::cerr << "Error: invalid value for LOCAL_ONLY. It must be either 'true' or 'false'." << std::endl;
+          logs::lerr << logs::error << "Error: invalid value for LOCAL_ONLY. It must be either 'true' or 'false'." << std::endl;
           abort();
         }
       }
@@ -209,14 +209,14 @@ namespace format {
 
     // option conflict check (do not set at the same time)
     if (score_only && local_only) {
-      std::cerr << "Error: 'score-only' and 'local-only' cannot be true at the same time." << std::endl;
+      logs::lerr << logs::error << "'score-only' and 'local-only' cannot be true at the same time." << std::endl;
       abort();
     }
     if (score_only && no_local_opt) {
-      std::cerr << "Warning: 'score-only' and 'no-local-opt' are both true. This means the same as 'score-only' only." << std::endl;
+      logs::lerr << logs::warn << "'score-only' and 'no-local-opt' are both true. This means the same as 'score-only' only." << std::endl;
     }
     if (local_only && no_local_opt) {
-      std::cerr << "Warning: 'local-only' and 'no-local-opt' are both true. This may the same as 'score-only'." << std::endl;
+      logs::lerr << logs::warn << "Warning: 'local-only' and 'no-local-opt' are both true. This may the same as 'score-only'." << std::endl;
     }
 
   }

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -187,7 +187,9 @@ namespace format {
     int FGRID_SIZE = (int)((mem_size * 1024 * 1024) / ((int64_t) num.x * num.y * num.z * sizeof(fltype))); // # of grids that can be stored in memory
     assert(FGRID_SIZE > 0);
 
-    // option conflict check
-    assert(score_only + local_only + no_local_opt <= 1);
+    // option conflict check (do not set at the same time)
+    assert(
+      !( (score_only && local_only) || (score_only && no_local_opt) || (local_only && no_local_opt) )
+    );
   }
 } // namespace format

--- a/src/infile_reader.hpp
+++ b/src/infile_reader.hpp
@@ -27,6 +27,9 @@ namespace format {
     fltype output_score_threshold = -3.0;
     fltype pose_rmsd = 0.5;
     bool no_local_opt = false;
+    bool score_only = false;
+    bool local_only = false;
+    fltype local_max_rmsd = -1;
     const std::string getReuseGridString() {
       switch (reuse_grid) {
         case ReuseStrategy::OFFLINE: return "REUSE_OFFLINE";

--- a/src/infile_reader.hpp
+++ b/src/infile_reader.hpp
@@ -25,7 +25,7 @@ namespace format {
     int64_t poses_per_lig = 1;
     int64_t poses_per_lig_before_opt = 2000;
     fltype output_score_threshold = -3.0;
-    fltype pose_rmsd = 0.5;
+    fltype pose_min_rmsd = 0.5;
     bool no_local_opt = false;
     bool score_only = false;
     bool local_only = false;

--- a/src/infile_reader.hpp
+++ b/src/infile_reader.hpp
@@ -29,7 +29,7 @@ namespace format {
     bool no_local_opt = false;
     bool score_only = false;
     bool local_only = false;
-    fltype local_max_rmsd = -1;
+    fltype local_max_rmsd = 1e10;
     const std::string getReuseGridString() {
       switch (reuse_grid) {
         case ReuseStrategy::OFFLINE: return "REUSE_OFFLINE";

--- a/src/log_writer_stream.cc
+++ b/src/log_writer_stream.cc
@@ -17,22 +17,29 @@ namespace {
 
 namespace logs{
   io::filtering_ostream lout;
+  io::filtering_ostream lerr;
   LogType info("INFO");
   LogType debug("DEBUG");
   LogType warn("WARN");
   LogType error("ERROR");
-  void log_init(const std::string& filename, bool verbose) {
+  void set_file(const std::string& filename, bool verbose) {
+    close();
     static std::ofstream ofs(filename.c_str()); // log file
     static io::tee_filter<std::ostream>  fileFilt(ofs); // tee all passed data to logfile
-    logs::lout.push(fileFilt); // 1st, tee off any data to the file (raw boost XML)
-    if (verbose) {
-      logs::lout.push(std::cout); // 2nd, tee off any data to cout (raw boost XML)
-    }
+    // 1st, tee off any data to the file (raw boost XML)
+    logs::lout.push(fileFilt); 
+    logs::lerr.push(fileFilt);
+    // 2nd, tee off any data to cout (raw boost XML)
+    if (verbose) logs::lout.push(std::cout); 
+    logs::lerr.push(std::cerr);
   }
   void close() {
     io::close(logs::lout);
+    io::close(logs::lerr);
   }
   std::ostream& operator<<(std::ostream& os, const LogType& lt) {
+    if (lout.empty()) lout.push(std::cout);
+    if (lerr.empty()) lerr.push(std::cerr);
     os << getDateString() << " [time=(" << time(NULL) << ")] [" << lt.type << "] ";
     return os;
   }

--- a/src/log_writer_stream.hpp
+++ b/src/log_writer_stream.hpp
@@ -16,11 +16,12 @@ namespace logs{
     LogType(const std::string& type) : type(type) {}
   };
   extern io::filtering_ostream lout;
+  extern io::filtering_ostream lerr;
   extern LogType info;
   extern LogType debug;
   extern LogType warn;
   extern LogType error;
-  void log_init(const std::string& filename, bool verbose = true);
+  void set_file(const std::string& filename, bool verbose = true);
   void close();
   std::ostream& operator<<(std::ostream& os, const LogType& lt);
 }


### PR DESCRIPTION
# 概要
- 新たに`--local-max-rmsd`, `--local-only`, `--score-only`の3オプションを追加
- log出力文の修正
# オプション仕様
## local-max-rmsd オプション
- 局所最適化時に最適化前からの移動をRMSDで制限するオプション
  - score-onlyまたはno-local-optが設定されている場合は、局所最適化をしないので効果なし（assertはかけていない）
- デフォルトは-1
  - 負の値は設定なしの意味
- `Optimizer`または`Optimizer_grid`のコンストラクタで渡す
  - `optimize`メソッドで渡すかは迷ったがオブジェクトごとに設定を保持している方が良いかと思い、上記の実装
  - `optimize`メソッドの入力molの座標とのRMSDが設定値を越えないように局所最適化を行う
    - 設定値が負の場合はRMSD制限なし
## local-only オプション
- 化合物ファイルの座標をそのまま用いて局所最適化を行うオプション
  - フラグメントグリッドの作成はなし
  - `score-only`または`no-local-opt`との併用不可
- 化合物ごとではなく**配座ごと**に出力
- csv出力なし
## score-only オプション
- 化合物ファイルの座標をそのまま用いてエネルギー計算を行うオプション
  - フラグメントグリッドの作成はなし
  - 原子グリッドを使用して計算
  - `local-only`または`no-local-opt`との併用不可
- 化合物ごとではなく**配座ごと**に出力
- csv出力なし
# その他
- `--rmsd`オプションがわかりづらかったので、AutoDock Vinaに合わせて`--min-rmsd`オプションに改名
- 雑にifブロックで区切りながら実装しているため、スコープの関係で複数の変数宣言が前倒しになっている
  - 初期化はなるべく変えていないはず
- logの出力文はオプションにおける変化を反映
  - ほぼ自分の趣味に沿って