### PR TITLE
OpenDXファイルによる原子グリッドの置換

### DIFF
--- a/src/AtomInterEnergyGrid.cc
+++ b/src/AtomInterEnergyGrid.cc
@@ -11,15 +11,13 @@ namespace fragdock {
     return inter_energy_grids;
   }
 
-  std::vector<std::pair<bool, AtomInterEnergyGrid> > AtomInterEnergyGrid::readDxAtomGrids(const std::string& dx_folder){
-    std::vector<std::pair<bool, AtomInterEnergyGrid> > inter_energy_grids(XS_TYPE_SIZE);
+  std::vector<AtomInterEnergyGrid> AtomInterEnergyGrid::readDxAtomGrids(const std::string& dx_folder){
+    std::vector<AtomInterEnergyGrid> inter_energy_grids = {};
 
     for (int i = 0; i < XS_TYPE_SIZE; i++) {
       std::string dx_filename = dx_folder + "/" + xs_strings[i] + ".dx";
       if (std::ifstream(dx_filename).good()) {
-        inter_energy_grids[i] = std::make_pair(true, AtomInterEnergyGrid(dx_filename, i));
-      } else {
-        inter_energy_grids[i] = std::make_pair(false, AtomInterEnergyGrid());
+        inter_energy_grids.push_back(AtomInterEnergyGrid(dx_filename, i));
       }
     }
     return inter_energy_grids;

--- a/src/AtomInterEnergyGrid.cc
+++ b/src/AtomInterEnergyGrid.cc
@@ -10,6 +10,21 @@ namespace fragdock {
     }
     return inter_energy_grids;
   }
+
+  std::vector<AtomInterEnergyGrid> AtomInterEnergyGrid::readDxAtomGrids(const std::string& dx_folder){
+    std::vector<AtomInterEnergyGrid> inter_energy_grids(XS_TYPE_SIZE);
+
+    for (int i = 0; i < XS_TYPE_SIZE; i++) {
+      std::string dx_filename = dx_folder + "/" + xs_strings[i] + ".dx";
+      if (std::ifstream(dx_filename).good()) {
+        inter_energy_grids[i] = AtomInterEnergyGrid(dx_filename, i);
+      } else {
+        inter_energy_grids[i] = AtomInterEnergyGrid();
+      }
+    }
+    return inter_energy_grids;
+  }
+
   std::vector<AtomInterEnergyGrid> AtomInterEnergyGrid::makeAtomGrids(const Point3d<fltype>& center,
                                                             const Point3d<fltype>& pitch,
                                                             const Point3d<int>& num,

--- a/src/AtomInterEnergyGrid.cc
+++ b/src/AtomInterEnergyGrid.cc
@@ -11,15 +11,15 @@ namespace fragdock {
     return inter_energy_grids;
   }
 
-  std::vector<AtomInterEnergyGrid> AtomInterEnergyGrid::readDxAtomGrids(const std::string& dx_folder){
-    std::vector<AtomInterEnergyGrid> inter_energy_grids(XS_TYPE_SIZE);
+  std::vector<std::pair<bool, AtomInterEnergyGrid> > AtomInterEnergyGrid::readDxAtomGrids(const std::string& dx_folder){
+    std::vector<std::pair<bool, AtomInterEnergyGrid> > inter_energy_grids(XS_TYPE_SIZE);
 
     for (int i = 0; i < XS_TYPE_SIZE; i++) {
       std::string dx_filename = dx_folder + "/" + xs_strings[i] + ".dx";
       if (std::ifstream(dx_filename).good()) {
-        inter_energy_grids[i] = AtomInterEnergyGrid(dx_filename, i);
+        inter_energy_grids[i] = std::make_pair(true, AtomInterEnergyGrid(dx_filename, i));
       } else {
-        inter_energy_grids[i] = AtomInterEnergyGrid();
+        inter_energy_grids[i] = std::make_pair(false, AtomInterEnergyGrid());
       }
     }
     return inter_energy_grids;

--- a/src/AtomInterEnergyGrid.hpp
+++ b/src/AtomInterEnergyGrid.hpp
@@ -20,6 +20,7 @@ namespace fragdock {
     ~AtomInterEnergyGrid() {}
     int getXSType() const { return xs_type; }
     static std::vector<AtomInterEnergyGrid> readAtomGrids(const std::string& grid_folder);
+    static std::vector<AtomInterEnergyGrid> readDxAtomGrids(const std::string& dx_folder);
     static std::vector<AtomInterEnergyGrid> makeAtomGrids(const Point3d<fltype>& center,
                                                      const Point3d<fltype>& pitch,
                                                      const Point3d<int>& num,

--- a/src/AtomInterEnergyGrid.hpp
+++ b/src/AtomInterEnergyGrid.hpp
@@ -20,7 +20,7 @@ namespace fragdock {
     ~AtomInterEnergyGrid() {}
     int getXSType() const { return xs_type; }
     static std::vector<AtomInterEnergyGrid> readAtomGrids(const std::string& grid_folder);
-    static std::vector<AtomInterEnergyGrid> readDxAtomGrids(const std::string& dx_folder);
+    static std::vector<std::pair<bool, AtomInterEnergyGrid> > readDxAtomGrids(const std::string& dx_folder);
     static std::vector<AtomInterEnergyGrid> makeAtomGrids(const Point3d<fltype>& center,
                                                      const Point3d<fltype>& pitch,
                                                      const Point3d<int>& num,

--- a/src/AtomInterEnergyGrid.hpp
+++ b/src/AtomInterEnergyGrid.hpp
@@ -20,7 +20,7 @@ namespace fragdock {
     ~AtomInterEnergyGrid() {}
     int getXSType() const { return xs_type; }
     static std::vector<AtomInterEnergyGrid> readAtomGrids(const std::string& grid_folder);
-    static std::vector<std::pair<bool, AtomInterEnergyGrid> > readDxAtomGrids(const std::string& dx_folder);
+    static std::vector<AtomInterEnergyGrid> readDxAtomGrids(const std::string& dx_folder);
     static std::vector<AtomInterEnergyGrid> makeAtomGrids(const Point3d<fltype>& center,
                                                      const Point3d<fltype>& pitch,
                                                      const Point3d<int>& num,

--- a/src/InterEnergyGrid.cc
+++ b/src/InterEnergyGrid.cc
@@ -16,6 +16,17 @@ namespace fragdock {
   fltype InterEnergyGrid::getInterEnergy(const Vector3d &pos) const {
     return getInterEnergy(convertX(pos), convertY(pos), convertZ(pos)); // nearest grid point
   }
+
+  void InterEnergyGrid::parseGrid(const std::string& filename) {
+    using namespace std;
+    ifstream ifs(filename.c_str(), ios::binary);
+    if(!ifs) {
+      cerr << "InterEnergyGrid::parseGrid() : file could not open. " << filename << endl;
+      return;
+    }
+    parseGrid(ifs);
+    ifs.close();
+  }
   
   void InterEnergyGrid::parseGrid(std::ifstream& ifs) {
     ifs.read(reinterpret_cast<char*>(&center), sizeof(center));
@@ -79,7 +90,6 @@ namespace fragdock {
 
   void InterEnergyGrid::parse(const std::string& filename) {
     using namespace std;
-    ifstream ifs;
     auto pos = filename.find_last_of(".");
     if (pos == string::npos) {
       cerr << "InterEnergyGrid::parse() : unknown file extension. " << filename << endl;
@@ -88,13 +98,7 @@ namespace fragdock {
     string extention = filename.substr(pos);
 
     if (extention == ".grid") {
-      ifs.open(filename.c_str(), ios::binary);
-      if(!ifs) {
-        cerr << "InterEnergyGrid::parse() : file could not open. " << filename << endl;
-        return;
-      }
-      parseGrid(ifs);
-      ifs.close();
+      parseGrid(filename);
     } else if (extention == ".dx") {
       parseDx(filename);
     } else {

--- a/src/InterEnergyGrid.cc
+++ b/src/InterEnergyGrid.cc
@@ -22,7 +22,7 @@ namespace fragdock {
     ifstream ifs(filename.c_str(), ios::binary);
     if(!ifs) {
       cerr << "InterEnergyGrid::parseGrid() : file could not open. " << filename << endl;
-      return;
+      abort();
     }
     parseGrid(ifs);
     ifs.close();
@@ -50,11 +50,11 @@ namespace fragdock {
 
     if (!conv.SetInFormat("dx")) {
       std::cerr << "InterEnergyGrid::parseDx() : could not set OpenDX format." << std::endl;
-      return;
+      abort();
     }
     if (!conv.ReadFile(&mol, filename)) {
       std::cerr << "InterEnergyGrid::parseDx() : failed to read file " << filename << std::endl;
-      return;
+      abort();
     }
 
     // Some OpenBabel installations expose only non-template GetData() overloads.
@@ -64,7 +64,7 @@ namespace fragdock {
     if (gd) grid = dynamic_cast<OpenBabel::OBGridData*>(gd);
     if (!grid) {
       std::cerr << "InterEnergyGrid::parseDx() : no grid data found in file " << filename << std::endl;
-      return;
+      abort();
     }
 
     grid->GetNumberOfPoints(num.x, num.y, num.z);
@@ -93,7 +93,7 @@ namespace fragdock {
     auto pos = filename.find_last_of(".");
     if (pos == string::npos) {
       cerr << "InterEnergyGrid::parse() : unknown file extension. " << filename << endl;
-      return;
+      abort();
     }
     string extention = filename.substr(pos);
 
@@ -103,6 +103,7 @@ namespace fragdock {
       parseDx(filename);
     } else {
       cerr << "InterEnergyGrid::parse() : unknown file extension. " << filename << endl;
+      abort();
     }
   }
 
@@ -125,7 +126,7 @@ namespace fragdock {
     ofstream ofs(filename.c_str(), ios::binary);
     if(!ofs){
       cerr << "InterEnergyGrid::WriteFile() : file could not open. " << filename << endl;
-      return ;
+      abort();
     }
     writeFile(ofs);
     ofs.close();

--- a/src/InterEnergyGrid.hpp
+++ b/src/InterEnergyGrid.hpp
@@ -76,7 +76,10 @@ namespace fragdock {
     Vector3d convert(const Point3d<int>& ind) const { return convert(ind.x, ind.y, ind.z); }
 
     /* Parse an energy grid data */
-    void parse(std::ifstream& ifs);
+    void parseGrid(std::ifstream& ifs);
+
+    /* Parse an energy OpenDX data */
+    void parseDx(std::ifstream& ifs);
 
     /* Parse an energy grid file */
     void parse(const std::string& filename);

--- a/src/InterEnergyGrid.hpp
+++ b/src/InterEnergyGrid.hpp
@@ -79,7 +79,7 @@ namespace fragdock {
     void parseGrid(std::ifstream& ifs);
 
     /* Parse an energy OpenDX data */
-    void parseDx(std::ifstream& ifs);
+    void parseDx(const std::string& filename);
 
     /* Parse an energy grid file */
     void parse(const std::string& filename);

--- a/src/InterEnergyGrid.hpp
+++ b/src/InterEnergyGrid.hpp
@@ -75,6 +75,9 @@ namespace fragdock {
     /* convert grid point indices to a 3d coordinate */
     Vector3d convert(const Point3d<int>& ind) const { return convert(ind.x, ind.y, ind.z); }
 
+    /* Parse an energy grid file */
+    void parseGrid(const std::string& filename);
+
     /* Parse an energy grid data */
     void parseGrid(std::ifstream& ifs);
 

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -49,7 +49,8 @@ namespace {
       ("poses-per-lig", value<int64_t>(), "Number of output poses per ligand")
       ("rmsd", value<fltype>(), "rmsd threshold for output poses")
       ("poses-per-lig-before-opt", value<int64_t>(), "Number of poses to be optimized per ligand")
-      ("output-score-threshold", value<fltype>(), "output score threshold");
+      ("output-score-threshold", value<fltype>(), "output score threshold")
+      ("dxgrid", value<std::string>(), "OpenDX grid folder");
     options_description desc;
     desc.add(options).add(hidden);
     variables_map vmap;
@@ -77,6 +78,7 @@ namespace {
     if (vmap.count("no-local-opt")) conf.no_local_opt = true;
     if (vmap.count("poses-per-lig-before-opt")) conf.poses_per_lig_before_opt = vmap["poses-per-lig-before-opt"].as<int64_t>();
     if (vmap.count("output-score-threshold")) conf.output_score_threshold = vmap["output-score-threshold"].as<fltype>();
+    if (vmap.count("dxgrid")) conf.dxgrid_folder = vmap["dxgrid"].as<std::string>();
     conf.checkConfigValidity();
     return conf;
   }
@@ -245,6 +247,17 @@ int main(int argc, char **argv){
   const Point3d<fltype>& search_pitch = config.grid.search_pitch;
   const Point3d<int> search_num = utils::ceili(config.grid.inner_width / 2 / search_pitch) * 2 + 1; // # of search grid points (conformer scoring)
   const InterEnergyGrid search_grid(atom_grids[0].getCenter(), search_pitch, search_num);
+
+  // replace atom grids with dx grids if exists
+  if (config.dxgrid_folder != "") {
+    vector<pair<bool, AtomInterEnergyGrid> > atom_dxgrids = AtomInterEnergyGrid::readDxAtomGrids(config.dxgrid_folder);
+    /* TODO: num, pitch, center should be the same */
+    // for (int i = 0; i < XS_TYPE_SIZE; i++) {
+    //   if (atom_dxgrids[i].first) {
+    //     atom_grids[i] = atom_dxgrids[i].second;
+    //   }
+    // }
+  }
 
 
   // The number how many fragment grids can be stored in memory.

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -263,11 +263,11 @@ int main(int argc, char **argv){
   if (config.dxgrid_folder != "") {
     vector<pair<bool, AtomInterEnergyGrid> > atom_dxgrids = AtomInterEnergyGrid::readDxAtomGrids(config.dxgrid_folder);
     /* TODO: num, pitch, center should be the same */
-    // for (int i = 0; i < XS_TYPE_SIZE; i++) {
-    //   if (atom_dxgrids[i].first) {
-    //     atom_grids[i] = atom_dxgrids[i].second;
-    //   }
-    // }
+    for (int i = 0; i < XS_TYPE_SIZE; i++) {
+      if (atom_dxgrids[i].first) {
+        atom_grids[i] = atom_dxgrids[i].second;
+      }
+    }
   }
 
 

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -53,7 +53,7 @@ namespace {
       ("min-rmsd", value<fltype>(), "minimum RMSD between output poses")
       ("poses-per-lig-before-opt", value<int64_t>(), "Number of poses to be optimized per ligand")
       ("output-score-threshold", value<fltype>(), "output score threshold")
-      ("dxgrid", value<std::string>(), "OpenDX grid folder");
+      ("dxgrid", value<std::string>(), "OpenDX grid folder (override .grid files if exists)");
     options_description desc;
     desc.add(options).add(hidden);
     variables_map vmap;

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -263,13 +263,9 @@ int main(int argc, char **argv){
   if (config.dxgrid_folder != "") {
     vector<AtomInterEnergyGrid> atom_dxgrids = AtomInterEnergyGrid::readDxAtomGrids(config.dxgrid_folder);
     /* TODO: num, pitch, center should be the same */
-    int j = 0;
-    for (int i = 0; i < XS_TYPE_SIZE; i++) {
-      if (j >= atom_dxgrids.size()) break;
-      if (atom_dxgrids[j].getXSType() == i) {
-        atom_grids[i] = atom_dxgrids[j];
-        j++;
-      }
+    for (int i = 0; i < atom_dxgrids.size(); i++) {
+      int xs_type = atom_dxgrids[i].getXSType();
+      atom_grids[xs_type] = atom_dxgrids[i];
     }
   }
 

--- a/src/fraggrid_main.cc
+++ b/src/fraggrid_main.cc
@@ -261,11 +261,14 @@ int main(int argc, char **argv){
 
   // replace atom grids with dx grids if exists
   if (config.dxgrid_folder != "") {
-    vector<pair<bool, AtomInterEnergyGrid> > atom_dxgrids = AtomInterEnergyGrid::readDxAtomGrids(config.dxgrid_folder);
+    vector<AtomInterEnergyGrid> atom_dxgrids = AtomInterEnergyGrid::readDxAtomGrids(config.dxgrid_folder);
     /* TODO: num, pitch, center should be the same */
+    int j = 0;
     for (int i = 0; i < XS_TYPE_SIZE; i++) {
-      if (atom_dxgrids[i].first) {
-        atom_grids[i] = atom_dxgrids[i].second;
+      if (j >= atom_dxgrids.size()) break;
+      if (atom_dxgrids[j].getXSType() == i) {
+        atom_grids[i] = atom_dxgrids[j];
+        j++;
       }
     }
   }

--- a/src/infile_reader.cc
+++ b/src/infile_reader.cc
@@ -154,6 +154,9 @@ namespace format {
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
         conf.no_local_opt = (str != "false");
       }
+      else if (boost::algorithm::starts_with(buffer, "DXGRID_FOLDER ")) {
+        conf.dxgrid_folder = buffer.substr(14);
+      }
     }
 
     return conf;

--- a/src/infile_reader.hpp
+++ b/src/infile_reader.hpp
@@ -17,7 +17,7 @@ namespace format {
     SearchGrid grid;
     std::vector<std::string> ligand_files;
     std::string receptor_file, output_file;
-    std::string log_file, grid_folder;
+    std::string log_file, grid_folder, dxgrid_folder;
     std::string rotangs_file;
     ReuseStrategy reuse_grid = ReuseStrategy::OFFLINE;
     bool reorder = true;


### PR DESCRIPTION
conformer-docking時、オプションで指定した`dx_folder`に`.dx`が存在する原子タイプは`.grid`ではなく`.dx`の方のデータを使う機能を追加しました。
`.dx`のグリッドが指定するボックスに一致しているかの判定機能は実装できていません。